### PR TITLE
fix(test): identify the console output from ubuntu 20 +

### DIFF
--- a/test/src/test.progress.js
+++ b/test/src/test.progress.js
@@ -18,14 +18,13 @@ describe("test.progress", () => {
 
         capcon.stopCapture(process.stdout);
 
-        var expected = [
-            "\u001b[32mFixing:\u001b[39m " + path2.direct.absolute,
-            "\n",
-            "\u001b[32mDone!\u001b[39m",
-            "\n",
-        ];
+        var expected = ["Fixing:", path2.direct.absolute, "Done!"];
 
-        assert.deepEqual(output, expected);
+        output = output.join(" ");
+
+        expected.forEach((value) => {
+            assert.isTrue(output.includes(value));
+        });
     });
     it("does not show progress bar if showProgressBar is set to false", async () => {
         var output = [];


### PR DESCRIPTION
Ubuntu 20 now outputs console logs correctly, this fix will make
it possible to read both the old and new versions of the outputs

```
+ expected <= ubuntu 18
- actual >= ubuntu 20

[
-  "Fixing: /home/runner/work/svg-fixer/svg-fixer/test/assets/broken-icons/single/x-square.svg"
+  "\u001b[32mFixing:\u001b[39m /home/runner/work/svg-fixer/svg-fixer/test/assets/broken-icons/single/x-square.svg"
   "\n"
-  "Done!"
+  "\u001b[32mDone!\u001b[39m"
   "\n"
]
```