### PR TITLE
Updated cli-progress to ^3.10.0 - Fixes zalgo issue from colors.js dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "1.4.1",
       "license": "MIT",
       "dependencies": {
+        "ansi-colors": "^4.1.1",
         "cli-progress": "^3.10.0",
-        "colors": "1.4.0",
         "fast-glob": "^3.2.7",
         "oslllo-potrace": "^1.1.4",
         "oslllo-svg2": "^0.3.1",
@@ -1208,7 +1208,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
       "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -1829,14 +1828,6 @@
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
       "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==",
       "dev": true
-    },
-    "node_modules/colors": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
-      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
-      "engines": {
-        "node": ">=0.1.90"
-      }
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -6871,8 +6862,7 @@
     "ansi-colors": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
-      "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
-      "dev": true
+      "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA=="
     },
     "ansi-escapes": {
       "version": "4.3.2",
@@ -7335,11 +7325,6 @@
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
       "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==",
       "dev": true
-    },
-    "colors": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
-      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA=="
     },
     "combined-stream": {
       "version": "1.0.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "cli-progress": "^3.10.0",
-        "colors": "^1.4.0",
+        "colors": "1.4.0",
         "fast-glob": "^3.2.7",
         "oslllo-potrace": "^1.1.4",
         "oslllo-svg2": "^0.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.4.1",
       "license": "MIT",
       "dependencies": {
-        "cli-progress": "^3.9.0",
+        "cli-progress": "^3.10.0",
         "colors": "^1.4.0",
         "fast-glob": "^3.2.7",
         "oslllo-potrace": "^1.1.4",
@@ -1744,11 +1744,10 @@
       }
     },
     "node_modules/cli-progress": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/cli-progress/-/cli-progress-3.9.0.tgz",
-      "integrity": "sha512-g7rLWfhAo/7pF+a/STFH/xPyosaL1zgADhI0OM83hl3c7S43iGvJWEAV2QuDOnQ8i6EMBj/u4+NTd0d5L+4JfA==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/cli-progress/-/cli-progress-3.10.0.tgz",
+      "integrity": "sha512-kLORQrhYCAtUPLZxqsAt2YJGOvRdt34+O6jl5cQGb7iF3dM55FQZlTR+rQyIK9JUcO9bBMwZsTlND+3dmFU2Cw==",
       "dependencies": {
-        "colors": "^1.1.2",
         "string-width": "^4.2.0"
       },
       "engines": {
@@ -7272,11 +7271,10 @@
       }
     },
     "cli-progress": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/cli-progress/-/cli-progress-3.9.0.tgz",
-      "integrity": "sha512-g7rLWfhAo/7pF+a/STFH/xPyosaL1zgADhI0OM83hl3c7S43iGvJWEAV2QuDOnQ8i6EMBj/u4+NTd0d5L+4JfA==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/cli-progress/-/cli-progress-3.10.0.tgz",
+      "integrity": "sha512-kLORQrhYCAtUPLZxqsAt2YJGOvRdt34+O6jl5cQGb7iF3dM55FQZlTR+rQyIK9JUcO9bBMwZsTlND+3dmFU2Cw==",
       "requires": {
-        "colors": "^1.1.2",
         "string-width": "^4.2.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "homepage": "https://docs.oslllo.com/svg-fixer/master",
   "dependencies": {
     "cli-progress": "^3.10.0",
-    "colors": "1.4.0",
+    "ansi-colors": "^4.1.1",
     "fast-glob": "^3.2.7",
     "oslllo-potrace": "^1.1.4",
     "oslllo-svg2": "^0.3.1",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "homepage": "https://docs.oslllo.com/svg-fixer/master",
   "dependencies": {
-    "cli-progress": "^3.9.0",
+    "cli-progress": "^3.10.0",
     "colors": "^1.4.0",
     "fast-glob": "^3.2.7",
     "oslllo-potrace": "^1.1.4",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "homepage": "https://docs.oslllo.com/svg-fixer/master",
   "dependencies": {
     "cli-progress": "^3.10.0",
-    "colors": "^1.4.0",
+    "colors": "1.4.0",
     "fast-glob": "^3.2.7",
     "oslllo-potrace": "^1.1.4",
     "oslllo-svg2": "^0.3.1",

--- a/src/cli.js
+++ b/src/cli.js
@@ -3,7 +3,7 @@
 "use strict";
 
 const SVGFixer = require("../");
-const colors = require("colors");
+const colors = require("ansi-colors");
 var argvs = require("yargs/yargs")(process.argv.slice(2)); // eslint-disable-line no-magic-numbers
 
 argvs

--- a/src/progress.js
+++ b/src/progress.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const colors = require("colors");
+const colors = require("ansi-colors");
 const cliprogress = require("cli-progress");
 
 const Progress = function (source, max) {


### PR DESCRIPTION
This packages depends on cli-progress which in turn depends on colors.js which has made a few waves on the internet the past few days. [Here is a full explanation](https://www.bleepingcomputer.com/news/security/dev-corrupts-npm-libs-colors-and-faker-breaking-thousands-of-apps/) for those who have not heard.

cli-progress has made a new release which fixes the problem by forcing the colors dependency to version 1.4.0: [read up on it here](https://github.com/npkgz/cli-progress/issues/116).

I ran the tests locally after my edit and all seemed to pass. Fingers crossed everything is OK, as I am not at all familiar with the codebase for this module. Let me know if anything looks wrong.