### PR TITLE
feat: closes #71 - add configurable trace resolution

### DIFF
--- a/docs/getting-started/basic-usage.md
+++ b/docs/getting-started/basic-usage.md
@@ -30,6 +30,7 @@ SVGFixer(source, destination, options);
 - `options` ([**Object**](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)): fixer option parameters.
     - `throwIfDestinationDoesNotExist` ([**Boolean**](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)): throw `TypeError` if destination path does not exist. **default(true)**
     - `showProgressBar` ([**Boolean**](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)) : show progress bar in CLI. **default(false)**
+    - `traceResolution` ([**Number**](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)) : resolution of the image to trace to create the new SVG.  Larger number is higher quality and slower processing.  **default(600)**
 
 ### Throws
 
@@ -50,7 +51,7 @@ var options = {
 
 SVGFixer('directory/containing/svgs', 'directory/to-store/fixed-svgs', options); // Returns instance
 
-// Or with a path that points directly so a single file.
+// Or with a path that points directly to a single file.
 
 SVGFixer('directory/containing/broken-icon.svg', 'directory/to-store/fixed-svgs', options); // Returns instance
 ```

--- a/scripts/debug.js
+++ b/scripts/debug.js
@@ -54,6 +54,12 @@ var questions = [
     message: "Throw if destination does not exist?",
     default: "Y",
   },
+  {
+    type: "input",
+    name: "traceResolution",
+    message: "Enter the resolution of the trace image",
+    default: 600,
+  },
 ];
 
 inquirer.prompt(questions).then(async (answers) => {
@@ -68,6 +74,7 @@ inquirer.prompt(questions).then(async (answers) => {
   var options = {
     showProgressBar: answers.showProgressBar,
     throwIfDestinationDoesNotExist: answers.throwIfDestinationDoesNotExist,
+    traceResolution: answers.traceResolution,
   };
   var stopwatch;
   fs.emptyDirSync(destination);

--- a/src/cli.js
+++ b/src/cli.js
@@ -32,6 +32,12 @@ argvs
     default: true,
     type: "boolean",
   })
+  .option("trace-resolution", {
+    alias: "tr",
+    describe: "resolution of trace image: larger == higher quality and slower processing",
+    default: 600,
+    type: "number",
+  })
   .help();
 
 argvs = argvs.argv;
@@ -41,6 +47,7 @@ const destination = argvs["destination"]; // eslint-disable-line dot-notation
 const options = {
   showProgressBar: argvs["show-progress"],
   throwIfDestinationDoesNotExist: argvs["strict-destination"],
+  traceResolution: argvs["trace-resolution"],
 };
 
 (async () => {

--- a/src/option.js
+++ b/src/option.js
@@ -7,6 +7,7 @@ const Option = function (options) {
   this.data = {
     showProgressBar: false,
     throwIfDestinationDoesNotExist: true,
+    traceResolution: 600,
   };
   if (!is.object(options)) {
     throw error.invalidParameterError("options", "object", options);

--- a/src/processor.js
+++ b/src/processor.js
@@ -71,7 +71,8 @@ Processor.prototype = {
   instance: function ({ source, destination }) {
     return new Promise(async (resolve, reject) => {
       try {
-        var svg = new Svg(source);
+        var resolution = this.fixer.options.get("traceResolution");
+        var svg = new Svg(source, resolution);
         var fixed = await svg.process();
         fs.writeFileSync(destination, fixed);
         this.tick(() => resolve());

--- a/src/svg.js
+++ b/src/svg.js
@@ -3,9 +3,10 @@
 const Svg2 = require("oslllo-svg2");
 const Potrace = require("oslllo-potrace");
 
-const Svg = function (path) {
+const Svg = function (path, traceResolution) {
   this.filled = false;
   this.path = path;
+  this.traceResolution = traceResolution;
   this.png = new Object();
   this.resized = new Object();
   this.svg2 = Svg2(this.path);
@@ -25,13 +26,12 @@ Svg.prototype = {
     return { element, svg2, dimensions };
   },
   getResizeDimensions() {
-    const width = 600;
-    const dimensions = {
+    const width = this.traceResolution;
+
+    return {
       width: width,
       height: (width / this.original.dimensions.width) * this.original.dimensions.height,
     };
-
-    return dimensions;
   },
   getOriginal: function () {
     var element = this.element.cloneNode(true);

--- a/test/src/test.parameters.js
+++ b/test/src/test.parameters.js
@@ -8,6 +8,7 @@ describe("test.parameters", () => {
       var options = {
         showProgressBar: true,
         throwIfDestinationDoesNotExist: false,
+        traceResolution: 600,
       };
       var instance = SVGFixer(path2.direct.absolute, path2.fixed.absolute, options);
       var set = instance.options.all();
@@ -26,6 +27,7 @@ describe("test.parameters", () => {
       var valid = {
         showProgressBar: false,
         throwIfDestinationDoesNotExist: true,
+        traceResolution: 600,
       };
       var invalid = {
         invalidoptions: true,


### PR DESCRIPTION
I've added a parameter to set the resolution on the trace image.  I called it `traceResolution` to avoid any confusion with that and the output resolution.  I don't think the process is explained in the docs, so it might be helpful to include a brief description of how the tool works.  I made a brief mention in the parameter documentation.