### PR TITLE
Introduce worker pools

### DIFF
--- a/.github/workflows/cd.release.yml
+++ b/.github/workflows/cd.release.yml
@@ -22,7 +22,7 @@ jobs:
         if: ${{ steps.release.outputs.release_created }}
       - uses: actions/setup-node@v1
         with:
-          node-version: 12
+          node-version: 18
           registry-url: 'https://registry.npmjs.org'
         if: ${{ steps.release.outputs.release_created }}
       # if you are using Yarn, substitute the command below with `yarn install --frozen-lockfile`

--- a/.github/workflows/ci.coverage.yml
+++ b/.github/workflows/ci.coverage.yml
@@ -11,10 +11,10 @@ jobs:
 
     - uses: actions/checkout@v1
 
-    - name: Use Node.js 10.x
+    - name: Use Node.js 18.x
       uses: actions/setup-node@v1
       with:
-        node-version: 10.x
+        node-version: 18
 
     - name: npm install, npm test, npm run coverage
       run: |

--- a/.github/workflows/ci.test.yml
+++ b/.github/workflows/ci.test.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [16.x, 18.x, 20.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,9 @@
         "mocha-lcov-reporter": "^1.3.0",
         "nyc": "^15.1.0",
         "stopwatch-node": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@assemblyscript/loader": {
@@ -1700,9 +1703,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001367",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001367.tgz",
-      "integrity": "sha512-XDgbeOHfifWV3GEES2B8rtsrADx4Jf+juKX2SICJcaUhjYBO3bR96kvEIHa15VU6ohtOhBZuPGGYGbXMRn0NCw==",
+      "version": "1.0.30001534",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001534.tgz",
+      "integrity": "sha512-vlPVrhsCS7XaSh2VvWluIQEzVhefrUQcEsQWSS5A5V+dM07uv1qHeQzAOTGIMy9i3e9bH15+muvI/UHojVgS/Q==",
       "dev": true,
       "funding": [
         {
@@ -1712,6 +1715,10 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ]
     },
@@ -6629,9 +6636,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001367",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001367.tgz",
-      "integrity": "sha512-XDgbeOHfifWV3GEES2B8rtsrADx4Jf+juKX2SICJcaUhjYBO3bR96kvEIHa15VU6ohtOhBZuPGGYGbXMRn0NCw==",
+      "version": "1.0.30001534",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001534.tgz",
+      "integrity": "sha512-vlPVrhsCS7XaSh2VvWluIQEzVhefrUQcEsQWSS5A5V+dM07uv1qHeQzAOTGIMy9i3e9bH15+muvI/UHojVgS/Q==",
       "dev": true
     },
     "caseless": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "oslllo-potrace": "^2.0.1",
         "oslllo-svg2": "^2.0.2",
         "oslllo-validator": "^3.1.0",
+        "piscina": "^4.1.0",
         "yargs": "^16.2.0"
       },
       "bin": {
@@ -33,6 +34,11 @@
         "nyc": "^15.1.0",
         "stopwatch-node": "^1.1.0"
       }
+    },
+    "node_modules/@assemblyscript/loader": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@assemblyscript/loader/-/loader-0.10.1.tgz",
+      "integrity": "sha512-H71nDOOL8Y7kWRLqf6Sums+01Q5msqBW2KhDUTemh1tvY04eSkSXrK0uj/4mmY0Xr16/3zyZmsrxN7CKuRbNRg=="
     },
     "node_modules/@babel/code-frame": {
       "version": "7.12.11",
@@ -2356,6 +2362,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eventemitter-asyncresource": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/eventemitter-asyncresource/-/eventemitter-asyncresource-1.0.0.tgz",
+      "integrity": "sha512-39F7TBIV0G7gTelxwbEqnwhp90eqCPON1k0NwNfwhgKn4Co4ybUbj2pECcXT0B3ztRKZ7Pw1JujUUgmQJHcVAQ=="
+    },
     "node_modules/exif-parser": {
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/exif-parser/-/exif-parser-0.1.12.tgz",
@@ -2808,6 +2819,21 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/hdr-histogram-js": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hdr-histogram-js/-/hdr-histogram-js-2.0.3.tgz",
+      "integrity": "sha512-Hkn78wwzWHNCp2uarhzQ2SGFLU3JY8SBDDd3TAABK4fc30wm+MuPOrg5QVFVfkKOQd6Bfz3ukJEI+q9sXEkK1g==",
+      "dependencies": {
+        "@assemblyscript/loader": "^0.10.1",
+        "base64-js": "^1.2.0",
+        "pako": "^1.0.3"
+      }
+    },
+    "node_modules/hdr-histogram-percentiles-obj": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hdr-histogram-percentiles-obj/-/hdr-histogram-percentiles-obj-3.0.0.tgz",
+      "integrity": "sha512-7kIufnBqdsBGcSZLPJwqHT3yhk1QTsSlFsVD3kx5ixH/AlgBs9yM1q6DPhXZ8f8gtdqgh7N7/5btRLpQsS2gHw=="
     },
     "node_modules/he": {
       "version": "1.2.0",
@@ -3771,6 +3797,37 @@
       "integrity": "sha512-AO81vsIO1k1sM4Zrd6Hu7regmJN1NSiAja10gc4bX3F0wd+9rQmcuHQaHVQCYIEC8iFXnE+mavh23GOt7wBgug==",
       "dev": true
     },
+    "node_modules/nice-napi": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/nice-napi/-/nice-napi-1.0.2.tgz",
+      "integrity": "sha512-px/KnJAJZf5RuBGcfD+Sp2pAKq0ytz8j+1NehvgIGFkvtvFrDM3T8E4x/JJODXK9WZow8RRGrbA9QQ3hs+pDhA==",
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "!win32"
+      ],
+      "dependencies": {
+        "node-addon-api": "^3.0.0",
+        "node-gyp-build": "^4.2.2"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
+      "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==",
+      "optional": true
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.6.1.tgz",
+      "integrity": "sha512-24vnklJmyRS8ViBNI8KbtK/r/DmXQMRiOMXTNz2nrTnAYUwjmEEbnnpB/+kt+yWRv73bPsSPRFddrcIbAxSiMQ==",
+      "optional": true,
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
+    },
     "node_modules/node-preload": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/node-preload/-/node-preload-0.2.1.tgz",
@@ -4262,6 +4319,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/piscina": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/piscina/-/piscina-4.1.0.tgz",
+      "integrity": "sha512-sjbLMi3sokkie+qmtZpkfMCUJTpbxJm/wvaPzU28vmYSsTSW8xk9JcFUsbqGJdtPpIQ9tuj+iDcTtgZjwnOSig==",
+      "dependencies": {
+        "eventemitter-asyncresource": "^1.0.0",
+        "hdr-histogram-js": "^2.0.1",
+        "hdr-histogram-percentiles-obj": "^3.0.0"
+      },
+      "optionalDependencies": {
+        "nice-napi": "^1.0.2"
       }
     },
     "node_modules/pixelmatch": {
@@ -5357,6 +5427,11 @@
     }
   },
   "dependencies": {
+    "@assemblyscript/loader": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@assemblyscript/loader/-/loader-0.10.1.tgz",
+      "integrity": "sha512-H71nDOOL8Y7kWRLqf6Sums+01Q5msqBW2KhDUTemh1tvY04eSkSXrK0uj/4mmY0Xr16/3zyZmsrxN7CKuRbNRg=="
+    },
     "@babel/code-frame": {
       "version": "7.12.11",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
@@ -7054,6 +7129,11 @@
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
     },
+    "eventemitter-asyncresource": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/eventemitter-asyncresource/-/eventemitter-asyncresource-1.0.0.tgz",
+      "integrity": "sha512-39F7TBIV0G7gTelxwbEqnwhp90eqCPON1k0NwNfwhgKn4Co4ybUbj2pECcXT0B3ztRKZ7Pw1JujUUgmQJHcVAQ=="
+    },
     "exif-parser": {
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/exif-parser/-/exif-parser-0.1.12.tgz",
@@ -7386,6 +7466,21 @@
           "dev": true
         }
       }
+    },
+    "hdr-histogram-js": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hdr-histogram-js/-/hdr-histogram-js-2.0.3.tgz",
+      "integrity": "sha512-Hkn78wwzWHNCp2uarhzQ2SGFLU3JY8SBDDd3TAABK4fc30wm+MuPOrg5QVFVfkKOQd6Bfz3ukJEI+q9sXEkK1g==",
+      "requires": {
+        "@assemblyscript/loader": "^0.10.1",
+        "base64-js": "^1.2.0",
+        "pako": "^1.0.3"
+      }
+    },
+    "hdr-histogram-percentiles-obj": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hdr-histogram-percentiles-obj/-/hdr-histogram-percentiles-obj-3.0.0.tgz",
+      "integrity": "sha512-7kIufnBqdsBGcSZLPJwqHT3yhk1QTsSlFsVD3kx5ixH/AlgBs9yM1q6DPhXZ8f8gtdqgh7N7/5btRLpQsS2gHw=="
     },
     "he": {
       "version": "1.2.0",
@@ -8127,6 +8222,28 @@
       "integrity": "sha512-AO81vsIO1k1sM4Zrd6Hu7regmJN1NSiAja10gc4bX3F0wd+9rQmcuHQaHVQCYIEC8iFXnE+mavh23GOt7wBgug==",
       "dev": true
     },
+    "nice-napi": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/nice-napi/-/nice-napi-1.0.2.tgz",
+      "integrity": "sha512-px/KnJAJZf5RuBGcfD+Sp2pAKq0ytz8j+1NehvgIGFkvtvFrDM3T8E4x/JJODXK9WZow8RRGrbA9QQ3hs+pDhA==",
+      "optional": true,
+      "requires": {
+        "node-addon-api": "^3.0.0",
+        "node-gyp-build": "^4.2.2"
+      }
+    },
+    "node-addon-api": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
+      "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==",
+      "optional": true
+    },
+    "node-gyp-build": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.6.1.tgz",
+      "integrity": "sha512-24vnklJmyRS8ViBNI8KbtK/r/DmXQMRiOMXTNz2nrTnAYUwjmEEbnnpB/+kt+yWRv73bPsSPRFddrcIbAxSiMQ==",
+      "optional": true
+    },
     "node-preload": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/node-preload/-/node-preload-0.2.1.tgz",
@@ -8518,6 +8635,17 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
       "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw=="
+    },
+    "piscina": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/piscina/-/piscina-4.1.0.tgz",
+      "integrity": "sha512-sjbLMi3sokkie+qmtZpkfMCUJTpbxJm/wvaPzU28vmYSsTSW8xk9JcFUsbqGJdtPpIQ9tuj+iDcTtgZjwnOSig==",
+      "requires": {
+        "eventemitter-asyncresource": "^1.0.0",
+        "hdr-histogram-js": "^2.0.1",
+        "hdr-histogram-percentiles-obj": "^3.0.0",
+        "nice-napi": "^1.0.2"
+      }
     },
     "pixelmatch": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "oslllo-potrace": "^2.0.1",
     "oslllo-svg2": "^2.0.2",
     "oslllo-validator": "^3.1.0",
+    "piscina": "^4.1.0",
     "yargs": "^16.2.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -10,11 +10,11 @@
   ],
   "scripts": {
     "debug": "node scripts/debug.js",
-    "lint": "node_modules/.bin/eslint -- src test ./",
-    "lint:fix": "node_modules/.bin/eslint --fix src test ./",
+    "lint": "./node_modules/.bin/eslint -- src test ./",
+    "lint:fix": "./node_modules/.bin/eslint --fix src test ./",
     "test:only": "nyc mocha test/main.test.js && mocha test/output.test.js",
     "test": "nyc mocha test/main.test.js && mocha test/output.test.js && npm run lint",
-    "coverage": "node_modules/.bin/nyc report --reporter=lcovonly"
+    "coverage": "./node_modules/.bin/nyc report --reporter=lcovonly"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "nyc": "^15.1.0",
     "stopwatch-node": "^1.1.0"
   },
-  "engines" : { 
-    "node" : ">=16.0.0"
+  "engines": {
+    "node": ">=16.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,11 +10,11 @@
   ],
   "scripts": {
     "debug": "node scripts/debug.js",
-    "lint": "./node_modules/.bin/eslint -- src test ./",
-    "lint:fix": "./node_modules/.bin/eslint --fix src test ./",
+    "lint": "eslint -- src test ./",
+    "lint:fix": "eslint --fix src test ./",
     "test:only": "nyc mocha test/main.test.js && mocha test/output.test.js",
     "test": "nyc mocha test/main.test.js && mocha test/output.test.js && npm run lint",
-    "coverage": "./node_modules/.bin/nyc report --reporter=lcovonly"
+    "coverage": "nyc report --reporter=lcovonly"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -63,5 +63,8 @@
     "mocha-lcov-reporter": "^1.3.0",
     "nyc": "^15.1.0",
     "stopwatch-node": "^1.1.0"
+  },
+  "engines" : { 
+    "node" : ">=16.0.0"
   }
 }

--- a/src/processor.js
+++ b/src/processor.js
@@ -48,8 +48,7 @@ Processor.prototype = {
 
         const workerPromises = svgs.map(async (svg) => {
           await workerPool.run(svg);
-          // eslint-disable-next-line no-empty-function
-          this.tick(() => {});
+          this.tick();
         });
 
         await Promise.all(workerPromises);
@@ -73,7 +72,8 @@ Processor.prototype = {
     if (is.defined(this.progress)) {
       this.progress.tick();
     }
-    callback();
+
+    return callback?.();
   },
   teardown: function () {
     if (is.defined(this.progress)) {

--- a/src/processor.js
+++ b/src/processor.js
@@ -48,7 +48,8 @@ Processor.prototype = {
 
         const workerPromises = svgs.map(async (svg) => {
           await workerPool.run(svg);
-          this.tick();
+          // eslint-disable-next-line no-empty-function
+          this.tick(() => {});
         });
 
         await Promise.all(workerPromises);
@@ -72,8 +73,7 @@ Processor.prototype = {
     if (is.defined(this.progress)) {
       this.progress.tick();
     }
-
-    return callback?.();
+    callback();
   },
   teardown: function () {
     if (is.defined(this.progress)) {

--- a/src/tracer.js
+++ b/src/tracer.js
@@ -1,0 +1,10 @@
+"use strict";
+
+const fs = require("fs");
+const Svg = require("./svg");
+
+module.exports = async ({ source, destination, resolution }) => {
+  const svg = new Svg(source, resolution);
+  const fixed = await svg.process();
+  fs.writeFileSync(destination, fixed);
+};

--- a/src/tracer.js
+++ b/src/tracer.js
@@ -1,10 +1,10 @@
 "use strict";
 
-const fs = require("fs");
+const fs = require("fs/promises");
 const Svg = require("./svg");
 
 module.exports = async ({ source, destination, resolution }) => {
   const svg = new Svg(source, resolution);
   const fixed = await svg.process();
-  fs.writeFileSync(destination, fixed);
+  await fs.writeFile(destination, fixed);
 };

--- a/test/src/test.cli.js
+++ b/test/src/test.cli.js
@@ -5,7 +5,7 @@ const { emptyDir, isEmptyDir } = require(".");
 const { exec } = require("child_process");
 const { assert, path2 } = require("./helper");
 
-const timeout = 20000;
+const timeout = 30000;
 var destination = "temp";
 
 if (!fs.existsSync(destination)) {


### PR DESCRIPTION
Thanks for your work on SVGFixer, great tool!
We switched to SVGFixer at [lucide-icons/lucide](https://github.com/lucide-icons/lucide)  to build our icon font. 
We outline/fix more than 1200 icons to make sure our font will build correctly. Only thing we noticed is that our build times are getting out of hand. It can sometimes go up to 7 min (in Github Actions).
So I am trying to see if we can improve the build speed.

I noticed that currently, the SVGFixer is working single-threaded. And that's maybe why it takes a bit of time when outlining a lot of icons. I was thinking maybe we could switch to multi-threading to speed things up. I experimented with [Piscina](https://github.com/piscinajs/piscina) to create a worker pool to trace the SVG files. And the results were stunning.

## Results

Tested on Macbook M2 Pro Max.

### Test with Single Threaded (current SVGFixer)
Duration: `2:24.109` (m:ss.mmm)

### Test with Multi Threading (current SVGFixer)
Duration: 17.158s

Screenshot: 
<img width="576" alt="Screenshot 2023-09-13 at 21 45 54" src="https://github.com/oslllo/svg-fixer/assets/11825403/1ff369d8-f9f8-432e-89d0-4f3933812941">

Curious what you think of this change!